### PR TITLE
Update Dockerfile: Add directives to install snmp and snmp-mibs-downloader

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,10 @@ FROM telegraf:1.17
 
 WORKDIR /
 
+RUN echo 'deb http://deb.debian.org/debian/ buster main contrib non-free\ndeb http://deb.debian.org/debian/ buster-updates main contrib non-free\ndeb http://security.debian.org/debian-security buster/updates main contrib non-free' > /etc/apt/sources.list
+
 RUN apt-get update \
-    && apt-get install -y python3 python3-pip \
+    && apt-get install -y python3 python3-pip snmp snmp-mibs-downloader\
     && rm -rf /var/lib/apt/lists/*
 
 COPY requirements.txt /


### PR DESCRIPTION
Hi, when I pulled the repo last week to test out the new container and plugin, I was getting missing MIB errors. I noticed that the old container had directives to install MIBs, so I added some to do the same here. Let me know if there was anything I missed.

Thanks,
Cameron Davie